### PR TITLE
refactor: Create grpc-exceptions-map.ts for GRPC_EXCEPTION_FROM_HTTP

### DIFF
--- a/lib/interceptors/http-to-grpc.interceptor.ts
+++ b/lib/interceptors/http-to-grpc.interceptor.ts
@@ -1,35 +1,12 @@
 import {
   CallHandler,
   ExecutionContext,
-  HttpStatus,
   Injectable,
   NestInterceptor,
 } from "@nestjs/common";
 import { Observable, throwError } from "rxjs";
 import { catchError } from "rxjs/operators";
-import {
-  GrpcAbortedException,
-  GrpcAlreadyExistsException,
-  GrpcInternalException,
-  GrpcInvalidArgumentException,
-  GrpcNotFoundException,
-  GrpcPermissionDeniedException,
-  GrpcResourceExhaustedException,
-  GrpcUnauthenticatedException,
-  GrpcUnknownException,
-} from "../exceptions";
-
-const GRPC_EXCEPTION_FROM_HTTP: Record<number, any> = {
-  [HttpStatus.NOT_FOUND]: GrpcNotFoundException,
-  [HttpStatus.FORBIDDEN]: GrpcPermissionDeniedException,
-  [HttpStatus.METHOD_NOT_ALLOWED]: GrpcAbortedException,
-  [HttpStatus.INTERNAL_SERVER_ERROR]: GrpcInternalException,
-  [HttpStatus.TOO_MANY_REQUESTS]: GrpcResourceExhaustedException,
-  [HttpStatus.BAD_GATEWAY]: GrpcUnknownException,
-  [HttpStatus.CONFLICT]: GrpcAlreadyExistsException,
-  [HttpStatus.UNPROCESSABLE_ENTITY]: GrpcInvalidArgumentException,
-  [HttpStatus.UNAUTHORIZED]: GrpcUnauthenticatedException,
-};
+import { GRPC_EXCEPTION_FROM_HTTP } from "../utils";
 
 @Injectable()
 export class HttpToGrpcInterceptor implements NestInterceptor {

--- a/lib/utils/grpc-exceptions-map.ts
+++ b/lib/utils/grpc-exceptions-map.ts
@@ -1,0 +1,24 @@
+import { HttpStatus } from "@nestjs/common";
+import {
+  GrpcAbortedException,
+  GrpcAlreadyExistsException,
+  GrpcInternalException,
+  GrpcInvalidArgumentException,
+  GrpcNotFoundException,
+  GrpcPermissionDeniedException,
+  GrpcResourceExhaustedException,
+  GrpcUnauthenticatedException,
+  GrpcUnknownException,
+} from "../exceptions";
+
+export const GRPC_EXCEPTION_FROM_HTTP: Record<number, any> = {
+  [HttpStatus.NOT_FOUND]: GrpcNotFoundException,
+  [HttpStatus.FORBIDDEN]: GrpcPermissionDeniedException,
+  [HttpStatus.METHOD_NOT_ALLOWED]: GrpcAbortedException,
+  [HttpStatus.INTERNAL_SERVER_ERROR]: GrpcInternalException,
+  [HttpStatus.TOO_MANY_REQUESTS]: GrpcResourceExhaustedException,
+  [HttpStatus.BAD_GATEWAY]: GrpcUnknownException,
+  [HttpStatus.CONFLICT]: GrpcAlreadyExistsException,
+  [HttpStatus.UNPROCESSABLE_ENTITY]: GrpcInvalidArgumentException,
+  [HttpStatus.UNAUTHORIZED]: GrpcUnauthenticatedException,
+};

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -1,2 +1,3 @@
 export * from "./error-object";
 export * from "./http-codes-map";
+export * from "./grpc-exceptions-map";


### PR DESCRIPTION
Of course, I use the [nestjs-grpc-exceptions](https://www.npmjs.com/package/nestjs-grpc-exceptions) package,
I often cite the mapping data([http-codes-map.ts](https://github.com/mohsenbostan/nestjs-grpc-exceptions/blob/main/lib/utils/http-codes-map.ts)).
However, the reverse map did not exist along with http-codes-map.ts, so using it as introduction material was disappointing.
From a code perspective, it seems better to have separate forward and reverse maps.
