### PR TITLE
fix(interceptor): fix rpc exception message in http to grpc interceptor

### DIFF
--- a/lib/interceptors/http-to-grpc.interceptor.ts
+++ b/lib/interceptors/http-to-grpc.interceptor.ts
@@ -40,7 +40,12 @@ export class HttpToGrpcInterceptor implements NestInterceptor {
         return throwError(
           () =>
             new RpcException({
-              message: exception.message,
+              message: JSON.stringify({
+                error: exception.message,
+                type:
+                  typeof exception.message === "string" ? "string" : "object",
+                exceptionName: RpcException.name,
+              }),
               code: statusCode,
             }),
         );


### PR DESCRIPTION
Handles all sorts of http exceptions from rpc client. No need to use extra try catch for parse error in grpc to http interceptor.

Refs: #13
Refs: #14