### PR TITLE
use tsup-node

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "type": "git",
     "url": "https://github.com/mohsenbostan/nestjs-grpc-exceptions.git"
   },
-  "version": "0.2.2",
+  "version": "0.2.3",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsup index.ts --format cjs,esm --dts",
+    "build": "tsup-node index.ts --format cjs,esm --dts",
     "test": "jest --",
     "test:coverage": "jest --collectCoverage --",
     "lint": "eslint \"{src,lib,test}/**/*.ts\" --fix",


### PR DESCRIPTION
If you are using tsup to build for Node.js applications/APIs, usually bundling dependencies is not needed, and it can even break things, for instance, while outputting to [ESM](https://nodejs.org/api/esm.html).

tsup automatically excludes packages specified in the dependencies and peerDependencies fields in the package.json, but if it somehow doesn't exclude some packages, this library also has a special executable tsup-node that automatically skips bundling any Node.js package.